### PR TITLE
[AMD] Fix segfault due to per vector callback mapping error

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -28,13 +28,16 @@ void lowerDistributedToShared(Location loc, Value src, Value dst,
 
   auto inEncoding = mlir::dyn_cast<BlockedEncodingAttr>(srcTy.getEncoding());
   if (inEncoding) {
-    auto outEncoding = mlir::cast<SharedEncodingAttr>(dstTy.getEncoding());
-    auto inOrd = inEncoding.getOrder();
-    auto outOrd = outEncoding.getOrder();
-    crossGrain = (inOrd[0] != outOrd[0]) && outEncoding.getInThreadTranspose();
-    assert(srcTy.getRank() <= 2 ||
-           (srcTy.getRank() == 3 && outOrd[2] == 0) &&
-               "Unexpected rank of ConvertLayout(blocked->shared)");
+    auto outEncoding = mlir::dyn_cast<SharedEncodingAttr>(dstTy.getEncoding());
+    if (outEncoding) {
+      auto inOrd = inEncoding.getOrder();
+      auto outOrd = outEncoding.getOrder();
+      crossGrain =
+          (inOrd[0] != outOrd[0]) && outEncoding.getInThreadTranspose();
+      assert(srcTy.getRank() <= 2 ||
+             (srcTy.getRank() == 3 && outOrd[2] == 0) &&
+                 "Unexpected rank of ConvertLayout(blocked->shared)");
+    }
   }
 
   auto elemTy = typeConverter->convertType(srcTy.getElementType());

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -447,10 +447,9 @@ void storeDistributedToShared(MemDescType dstTy, RankedTensorType srcTy,
                          &numElementsPerIter](VectorType vecTy, Value vecAddr) {
       Value vec = undef(vecTy);
       for (int i = 0; i < vecTy.getNumElements(); i++) {
-        auto inner_offset = val_outer_counter % innerVectorization;
-        auto outer_offset = val_inner_counter * innerVectorization;
-        auto row_offset = val_outer_counter / innerVectorization;
-        auto idx = inner_offset + outer_offset + row_offset;
+        auto column_offset = val_outer_counter % innerVectorization;
+        auto row_offset = val_inner_counter * innerVectorization;
+        auto idx = row_offset + column_offset;
         val_inner_counter = (val_inner_counter + 1) % outer_dim;
         if (val_inner_counter == 0)
           val_outer_counter++;

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -133,7 +133,7 @@ def TritonAMDGPUInThreadTranspose: Pass<"tritonamdgpu-in-thread-transpose", "mli
 
   let constructor = "mlir::createTritonAMDGPUInThreadTransposePass()";
 
-  let dependentDialects = [];
+  let dependentDialects = ["mlir::triton::amdgpu::TritonAMDGPUDialect"];
 }
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -210,7 +210,9 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
          (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
   auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
 
-  auto sharedLayout = cast<SharedEncodingAttr>(aTensorTy.getEncoding());
+  auto sharedLayout = dyn_cast<SharedEncodingAttr>(aTensorTy.getEncoding());
+  if (!sharedLayout)
+    return Value();
   auto order = sharedLayout.getOrder();
   assert((rank == 2 || order[2] == 0) &&
          "expect batch to be the slowest dimension");


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Fixes several "unsafe" pieces of the code and avoids a segfault in the per vector callback (which may not be correct).

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
